### PR TITLE
Normalize env vars to RIFFLUX and update workspace MCP config

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,25 @@
+{
+    "servers": {
+        "rifflux": {
+            "type": "stdio",
+            "command": "${workspaceFolder}/.venv/Scripts/python.exe",
+            "args": [
+                "-m",
+                "rifflux.mcp.server"
+            ],
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/src",
+                "RIFFLUX_DB_PATH": "${workspaceFolder}/rifflux.db",
+                "RIFFLUX_EMBEDDING_BACKEND": "hash",
+                "RIFFLUX_AUTO_REINDEX_ON_SEARCH": "1",
+                "RIFFLUX_AUTO_REINDEX_PATHS": "${workspaceFolder}",
+                "RIFFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS": "1.0",
+                "RIFFLUX_LOG_LEVEL": "DEBUG"
+            },
+            "dev": {
+                "watch": "${workspaceFolder}/src/**/*.py",
+                "debug": true
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -55,66 +55,67 @@ Core retrieval engine with deterministic chunking, incremental indexing, hybrid 
 
 Rifflux supports a configurable embedding backend via environment variables:
 
-- `RIFLUX_EMBEDDING_BACKEND=auto|onnx|hash` (default `auto`)
-- `RIFLUX_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5`
-- `RIFLUX_EMBEDDING_DIM=384`
-- `RIFLUX_DB_PATH=.tmp/rifflux/rifflux.db`
-- `RIFLUX_INDEX_INCLUDE_GLOBS=*.md` (comma-separated)
-- `RIFLUX_INDEX_EXCLUDE_GLOBS=.git/*,.venv/*,**/__pycache__/*,**/.pytest_cache/*,**/.ruff_cache/*,**/node_modules/*` (comma-separated)
-- `RIFLUX_AUTO_REINDEX_ON_SEARCH=0|1` (default `0`)
-- `RIFLUX_AUTO_REINDEX_PATHS=.` (comma-separated paths)
-- `RIFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS=2.0`
-- `RIFLUX_FILE_WATCHER=0|1` (default `0`)
-- `RIFLUX_FILE_WATCHER_PATHS=` (comma-separated directories to watch; required when watcher is enabled)
-- `RIFLUX_FILE_WATCHER_DEBOUNCE_MS=500` (minimum ms between FS event batches)
+- Canonical prefix: `RIFFLUX_*`
+- `RIFFLUX_EMBEDDING_BACKEND=auto|onnx|hash` (default `auto`)
+- `RIFFLUX_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5`
+- `RIFFLUX_EMBEDDING_DIM=384`
+- `RIFFLUX_DB_PATH=.tmp/riflux/rifflux.db`
+- `RIFFLUX_INDEX_INCLUDE_GLOBS=*.md` (comma-separated)
+- `RIFFLUX_INDEX_EXCLUDE_GLOBS=.git/*,.venv/*,**/__pycache__/*,**/.pytest_cache/*,**/.ruff_cache/*,**/node_modules/*` (comma-separated)
+- `RIFFLUX_AUTO_REINDEX_ON_SEARCH=0|1` (default `0`)
+- `RIFFLUX_AUTO_REINDEX_PATHS=.` (comma-separated paths)
+- `RIFFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS=2.0`
+- `RIFFLUX_FILE_WATCHER=0|1` (default `0`)
+- `RIFFLUX_FILE_WATCHER_PATHS=` (comma-separated directories to watch; required when watcher is enabled)
+- `RIFFLUX_FILE_WATCHER_DEBOUNCE_MS=500` (minimum ms between FS event batches)
 
 ### Environment variables reference
 
 | Variable | What it controls | Default | Example value |
 |---|---|---|---|
-| `RIFLUX_EMBEDDING_BACKEND` | Embedding backend strategy (`auto`, `onnx`, `hash`) | `auto` | `onnx` |
-| `RIFLUX_EMBEDDING_MODEL` | Preferred model label used by ONNX-capable path | `BAAI/bge-small-en-v1.5` | `BAAI/bge-small-en-v1.5` |
-| `RIFLUX_EMBEDDING_DIM` | Embedding vector dimension expected by runtime/store | `384` | `384` |
-| `RIFLUX_DB_PATH` | SQLite DB file location for index and embeddings | `.tmp/riflux/riflux.db` | `.tmp/riflux/my-index.db` |
-| `RIFLUX_INDEX_INCLUDE_GLOBS` | Comma-separated file patterns to include in indexing | `*.md` | `*.md,*.txt` |
-| `RIFLUX_INDEX_EXCLUDE_GLOBS` | Comma-separated file patterns to exclude from indexing | `.git/*,.venv/*,**/__pycache__/*,**/.pytest_cache/*,**/.ruff_cache/*,**/node_modules/*` | `.git/*,.venv/*,**/node_modules/*,build/*` |
-| `RIFLUX_AUTO_REINDEX_ON_SEARCH` | Whether search calls trigger incremental background refresh | `0` | `1` |
-| `RIFLUX_AUTO_REINDEX_PATHS` | Paths scanned when auto-reindex on search is enabled | `.` | `docs,notes` |
-| `RIFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS` | Minimum seconds between auto-reindex runs per DB | `2.0` | `10.0` |
-| `RIFLUX_FILE_WATCHER` | Whether filesystem watcher integration is enabled | `0` | `1` |
-| `RIFLUX_FILE_WATCHER_PATHS` | Comma-separated directories monitored by watcher | empty | `docs,knowledge-base` |
-| `RIFLUX_FILE_WATCHER_DEBOUNCE_MS` | Event debounce window before watcher emits a batch | `500` | `750` |
-| `RIFLUX_LOG_LEVEL` | Logging verbosity for CLI and MCP server | `WARNING` | `DEBUG` |
+| `RIFFLUX_EMBEDDING_BACKEND` | Embedding backend strategy (`auto`, `onnx`, `hash`) | `auto` | `onnx` |
+| `RIFFLUX_EMBEDDING_MODEL` | Preferred model label used by ONNX-capable path | `BAAI/bge-small-en-v1.5` | `BAAI/bge-small-en-v1.5` |
+| `RIFFLUX_EMBEDDING_DIM` | Embedding vector dimension expected by runtime/store | `384` | `384` |
+| `RIFFLUX_DB_PATH` | SQLite DB file location for index and embeddings | `.tmp/riflux/rifflux.db` | `.tmp/riflux/my-index.db` |
+| `RIFFLUX_INDEX_INCLUDE_GLOBS` | Comma-separated file patterns to include in indexing | `*.md` | `*.md,*.txt` |
+| `RIFFLUX_INDEX_EXCLUDE_GLOBS` | Comma-separated file patterns to exclude from indexing | `.git/*,.venv/*,**/__pycache__/*,**/.pytest_cache/*,**/.ruff_cache/*,**/node_modules/*` | `.git/*,.venv/*,**/node_modules/*,build/*` |
+| `RIFFLUX_AUTO_REINDEX_ON_SEARCH` | Whether search calls trigger incremental background refresh | `0` | `1` |
+| `RIFFLUX_AUTO_REINDEX_PATHS` | Paths scanned when auto-reindex on search is enabled | `.` | `docs,notes` |
+| `RIFFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS` | Minimum seconds between auto-reindex runs per DB | `2.0` | `10.0` |
+| `RIFFLUX_FILE_WATCHER` | Whether filesystem watcher integration is enabled | `0` | `1` |
+| `RIFFLUX_FILE_WATCHER_PATHS` | Comma-separated directories monitored by watcher | empty | `docs,knowledge-base` |
+| `RIFFLUX_FILE_WATCHER_DEBOUNCE_MS` | Event debounce window before watcher emits a batch | `500` | `750` |
+| `RIFFLUX_LOG_LEVEL` | Logging verbosity for CLI and MCP server | `WARNING` | `DEBUG` |
 
 ### Example configurations
 
 Minimal deterministic local setup (hash backend):
 
 ```bash
-RIFLUX_EMBEDDING_BACKEND=hash
-RIFLUX_DB_PATH=.tmp/riflux/riflux.db
-RIFLUX_LOG_LEVEL=INFO
+RIFFLUX_EMBEDDING_BACKEND=hash
+RIFFLUX_DB_PATH=.tmp/riflux/rifflux.db
+RIFFLUX_LOG_LEVEL=INFO
 ```
 
 Higher-quality semantic setup (ONNX preferred):
 
 ```bash
-RIFLUX_EMBEDDING_BACKEND=onnx
-RIFLUX_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
-RIFLUX_DB_PATH=.tmp/riflux/riflux.db
-RIFLUX_LOG_LEVEL=INFO
+RIFFLUX_EMBEDDING_BACKEND=onnx
+RIFFLUX_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+RIFFLUX_DB_PATH=.tmp/riflux/rifflux.db
+RIFFLUX_LOG_LEVEL=INFO
 ```
 
 Auto-refresh + watcher setup for active docs workspace:
 
 ```bash
-RIFLUX_EMBEDDING_BACKEND=auto
-RIFLUX_AUTO_REINDEX_ON_SEARCH=1
-RIFLUX_AUTO_REINDEX_PATHS=docs,notes
-RIFLUX_FILE_WATCHER=1
-RIFLUX_FILE_WATCHER_PATHS=docs,notes
-RIFLUX_FILE_WATCHER_DEBOUNCE_MS=500
-RIFLUX_LOG_LEVEL=DEBUG
+RIFFLUX_EMBEDDING_BACKEND=auto
+RIFFLUX_AUTO_REINDEX_ON_SEARCH=1
+RIFFLUX_AUTO_REINDEX_PATHS=docs,notes
+RIFFLUX_FILE_WATCHER=1
+RIFFLUX_FILE_WATCHER_PATHS=docs,notes
+RIFFLUX_FILE_WATCHER_DEBOUNCE_MS=500
+RIFFLUX_LOG_LEVEL=DEBUG
 ```
 
 Behavior:
@@ -123,7 +124,7 @@ Behavior:
 - `onnx`: ONNX-capable embedder path via optional dependency, falls back to hash if unavailable
 - `auto`: try ONNX path first, then hash fallback
 - indexing scope: include/exclude globs are applied by the MCP server during reindex
-- optional live refresh: if `RIFLUX_AUTO_REINDEX_ON_SEARCH=1`, each search performs incremental reindex over `RIFLUX_AUTO_REINDEX_PATHS` (throttled by `RIFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS`)
+- optional live refresh: if `RIFFLUX_AUTO_REINDEX_ON_SEARCH=1`, each search performs incremental reindex over `RIFFLUX_AUTO_REINDEX_PATHS` (throttled by `RIFFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS`)
 
 ### Embedding model choice
 
@@ -139,9 +140,9 @@ Quick operational defaults:
 
 File watcher:
 
-- When `RIFLUX_FILE_WATCHER=1` and `RIFLUX_FILE_WATCHER_PATHS` is set, Riflux monitors those paths for file changes and automatically triggers background reindex.
+- When `RIFFLUX_FILE_WATCHER=1` and `RIFFLUX_FILE_WATCHER_PATHS` is set, Riflux monitors those paths for file changes and automatically triggers background reindex.
 - The watcher uses `watchfiles` (Rust-backed, cross-platform). Install with `pip install -e .[watch]` or `pip install -e .[dev]`.
-- Only files matching `RIFLUX_INDEX_INCLUDE_GLOBS` (and not excluded) trigger reindex jobs.
+- Only files matching `RIFFLUX_INDEX_INCLUDE_GLOBS` (and not excluded) trigger reindex jobs.
 - The watcher auto-restarts on transient OS errors (up to 5 consecutive crashes with exponential backoff).
 - The watcher starts lazily on the first search call, not at server startup.
 
@@ -152,7 +153,7 @@ Schema-change policy:
 
 Default DB location:
 
-- If `RIFLUX_DB_PATH` is not set, Rifflux uses `.tmp/rifflux/rifflux.db`.
+- If `RIFFLUX_DB_PATH` is not set, Rifflux uses `.tmp/rifflux/rifflux.db`.
 - The `.tmp/` folder is git-ignored by default.
 
 ## Running as an MCP server
@@ -160,18 +161,18 @@ Default DB location:
 Rifflux MCP defaults are environment-variable driven.
 
 - Preferred configuration surface: environment variables (especially when launched by MCP hosts).
-- If `RIFLUX_DB_PATH` is omitted, DB files are created under `.tmp/rifflux/`.
+- If `RIFFLUX_DB_PATH` is omitted, DB files are created under `.tmp/rifflux/`.
 - Relative paths are resolved from the MCP server process working directory.
 
 Example environment setup:
 
-- `RIFLUX_DB_PATH=.tmp/rifflux/rifflux.db`
-- `RIFLUX_EMBEDDING_BACKEND=auto`
-- `RIFLUX_AUTO_REINDEX_ON_SEARCH=0`
+- `RIFFLUX_DB_PATH=.tmp/rifflux/rifflux.db`
+- `RIFFLUX_EMBEDDING_BACKEND=auto`
+- `RIFFLUX_AUTO_REINDEX_ON_SEARCH=0`
 
 Tip:
 
-- Use an absolute `RIFLUX_DB_PATH` if your MCP host runs from a different working directory than expected.
+- Use an absolute `RIFFLUX_DB_PATH` if your MCP host runs from a different working directory than expected.
 
 To enable ONNX-capable backend support:
 
@@ -253,11 +254,11 @@ Rifflux emits structured debug logs via Python `logging` under these loggers:
 - `rifflux.indexing` — file scan counts, per-file skip/index decisions, chunk+embed timing
 - `rifflux.retrieval` — lexical/semantic/embed phase durations and hit counts
 
-Set `RIFLUX_LOG_LEVEL` to control verbosity:
+Set `RIFFLUX_LOG_LEVEL` to control verbosity:
 
-- `RIFLUX_LOG_LEVEL=DEBUG` — full timing and decision traces (recommended for diagnosing slow tool calls)
-- `RIFLUX_LOG_LEVEL=INFO` — high-level summaries only
-- `RIFLUX_LOG_LEVEL=WARNING` — default, silent unless something is wrong
+- `RIFFLUX_LOG_LEVEL=DEBUG` — full timing and decision traces (recommended for diagnosing slow tool calls)
+- `RIFFLUX_LOG_LEVEL=INFO` — high-level summaries only
+- `RIFFLUX_LOG_LEVEL=WARNING` — default, silent unless something is wrong
 
 Example output at `DEBUG` level:
 
@@ -270,13 +271,13 @@ Example output at `DEBUG` level:
 For VS Code MCP server usage, add to `.vscode/mcp.json` env:
 
 ```json
-"RIFLUX_LOG_LEVEL": "DEBUG"
+"RIFFLUX_LOG_LEVEL": "DEBUG"
 ```
 
 For CLI usage:
 
 ```bash
-RIFLUX_LOG_LEVEL=DEBUG rifflux-query "cache ttl" --mode hybrid
+RIFFLUX_LOG_LEVEL=DEBUG rifflux-query "cache ttl" --mode hybrid
 ```
 
 ## Troubleshooting
@@ -284,4 +285,5 @@ RIFLUX_LOG_LEVEL=DEBUG rifflux-query "cache ttl" --mode hybrid
 - If search or reindex fails with SQL errors like `no such column: vec` or FTS mismatch errors, rebuild the DB schema and reindex:
    - `rifflux-rebuild --path . --db .tmp/rifflux/rifflux.db`
 - If background reindex jobs fail with `database is locked`, they are automatically retried (up to 3 times). Check `index_status` for job details and retry counts.
-- If the file watcher stops unexpectedly, it auto-restarts with backoff. After 5 consecutive crashes it gives up — check logs at `RIFLUX_LOG_LEVEL=DEBUG`.
+- If the file watcher stops unexpectedly, it auto-restarts with backoff. After 5 consecutive crashes it gives up — check logs at `RIFFLUX_LOG_LEVEL=DEBUG`.
+

--- a/scripts/inspect_mcp_tools.py
+++ b/scripts/inspect_mcp_tools.py
@@ -24,9 +24,9 @@ def _build_parameters(db_path: str | None) -> StdioServerParameters:
         "PYTHONPATH": "src",
     }
     if db_path:
-        env["RIFLUX_DB_PATH"] = db_path
-    if backend := os.getenv("RIFLUX_EMBEDDING_BACKEND"):
-        env["RIFLUX_EMBEDDING_BACKEND"] = backend
+        env["RIFFLUX_DB_PATH"] = db_path
+    if backend := os.getenv("RIFFLUX_EMBEDDING_BACKEND"):
+        env["RIFFLUX_EMBEDDING_BACKEND"] = backend
 
     return StdioServerParameters(
         command=str(python_exe),
@@ -73,7 +73,7 @@ def main() -> None:
     parser.add_argument(
         "--db-path",
         default=None,
-        help="Optional database path to pass as RIFLUX_DB_PATH.",
+        help="Optional database path to pass as RIFFLUX_DB_PATH.",
     )
     parser.add_argument(
         "--pretty",

--- a/src/rifflux/cli.py
+++ b/src/rifflux/cli.py
@@ -11,7 +11,7 @@ from rifflux.mcp.tools import reindex, search_rifflux
 
 
 def _configure_logging() -> None:
-    level_name = os.getenv("RIFLUX_LOG_LEVEL", "WARNING").upper()
+    level_name = os.getenv("RIFFLUX_LOG_LEVEL", "WARNING").upper()
     level = getattr(logging, level_name, logging.WARNING)
     logging.basicConfig(
         level=level,

--- a/src/rifflux/config.py
+++ b/src/rifflux/config.py
@@ -6,6 +6,10 @@ from pathlib import Path
 DEFAULT_DB_PATH = Path(".tmp") / "rifflux" / "rifflux.db"
 
 
+def _env(name: str, default: str) -> str:
+    return os.getenv(f"RIFFLUX_{name}", default)
+
+
 def _parse_glob_list(value: str) -> tuple[str, ...]:
     return tuple(item.strip() for item in value.split(",") if item.strip())
 
@@ -38,39 +42,40 @@ class RiffluxConfig:
     file_watcher_enabled: bool = False
     file_watcher_paths: tuple[str, ...] = ()
     file_watcher_debounce_ms: int = 500
+
     @classmethod
     def from_env(cls) -> "RiffluxConfig":
-        db_path = Path(os.getenv("RIFLUX_DB_PATH", str(DEFAULT_DB_PATH)))
-        max_chunk_chars = int(os.getenv("RIFLUX_MAX_CHUNK_CHARS", "2000"))
-        min_chunk_chars = int(os.getenv("RIFLUX_MIN_CHUNK_CHARS", "120"))
-        rrf_k = int(os.getenv("RIFLUX_RRF_K", "60"))
-        embedding_backend = os.getenv("RIFLUX_EMBEDDING_BACKEND", "auto")
-        embedding_dim = int(os.getenv("RIFLUX_EMBEDDING_DIM", "384"))
-        embedding_model = os.getenv("RIFLUX_EMBEDDING_MODEL", "BAAI/bge-small-en-v1.5")
-        index_include_globs = _parse_glob_list(os.getenv("RIFLUX_INDEX_INCLUDE_GLOBS", "*.md"))
+        db_path = Path(_env("DB_PATH", str(DEFAULT_DB_PATH)))
+        max_chunk_chars = int(_env("MAX_CHUNK_CHARS", "2000"))
+        min_chunk_chars = int(_env("MIN_CHUNK_CHARS", "120"))
+        rrf_k = int(_env("RRF_K", "60"))
+        embedding_backend = _env("EMBEDDING_BACKEND", "auto")
+        embedding_dim = int(_env("EMBEDDING_DIM", "384"))
+        embedding_model = _env("EMBEDDING_MODEL", "BAAI/bge-small-en-v1.5")
+        index_include_globs = _parse_glob_list(_env("INDEX_INCLUDE_GLOBS", "*.md"))
         index_exclude_globs = _parse_glob_list(
-            os.getenv(
-                "RIFLUX_INDEX_EXCLUDE_GLOBS",
+            _env(
+                "INDEX_EXCLUDE_GLOBS",
                 ".git/*,.venv/*,**/__pycache__/*,**/.pytest_cache/*,**/.ruff_cache/*,**/node_modules/*",
             )
         )
         auto_reindex_on_search = _parse_bool(
-            os.getenv("RIFLUX_AUTO_REINDEX_ON_SEARCH", "0")
+            _env("AUTO_REINDEX_ON_SEARCH", "0")
         )
         auto_reindex_paths = _parse_glob_list(
-            os.getenv("RIFLUX_AUTO_REINDEX_PATHS", ".")
+            _env("AUTO_REINDEX_PATHS", ".")
         )
         auto_reindex_min_interval_seconds = float(
-            os.getenv("RIFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS", "2.0")
+            _env("AUTO_REINDEX_MIN_INTERVAL_SECONDS", "2.0")
         )
         file_watcher_enabled = _parse_bool(
-            os.getenv("RIFLUX_FILE_WATCHER", "0")
+            _env("FILE_WATCHER", "0")
         )
         file_watcher_paths = _parse_glob_list(
-            os.getenv("RIFLUX_FILE_WATCHER_PATHS", "")
+            _env("FILE_WATCHER_PATHS", "")
         )
         file_watcher_debounce_ms = int(
-            os.getenv("RIFLUX_FILE_WATCHER_DEBOUNCE_MS", "500")
+            _env("FILE_WATCHER_DEBOUNCE_MS", "500")
         )
         return cls(
             db_path=db_path,

--- a/src/rifflux/mcp/server.py
+++ b/src/rifflux/mcp/server.py
@@ -22,7 +22,7 @@ from rifflux.mcp.tools import (
 
 
 def create_server(db_path: Path | None = None) -> FastMCP:
-    configured_db = Path(os.getenv("RIFLUX_DB_PATH", str(RiffluxConfig.from_env().db_path)))
+    configured_db = Path(os.getenv("RIFFLUX_DB_PATH", str(RiffluxConfig.from_env().db_path)))
     resolved_db_path = db_path or configured_db
     mcp = FastMCP("rifflux")
 
@@ -133,7 +133,7 @@ def create_server(db_path: Path | None = None) -> FastMCP:
 
 
 def _configure_logging() -> None:
-    level_name = os.getenv("RIFLUX_LOG_LEVEL", "WARNING").upper()
+    level_name = os.getenv("RIFFLUX_LOG_LEVEL", "WARNING").upper()
     level = getattr(logging, level_name, logging.WARNING)
     logging.basicConfig(
         level=level,

--- a/src/rifflux/mcp/tools.py
+++ b/src/rifflux/mcp/tools.py
@@ -52,7 +52,7 @@ def _raise_with_rebuild_hint(
     detail = str(exc).strip() or "sqlite operational error"
     hint = (
         f"{detail}. If this is due to a schema mismatch, rebuild the DB: "
-        f"`riflux-rebuild --path {source_arg} --db {target_db}` "
+        f"`rifflux-rebuild --path {source_arg} --db {target_db}` "
         f"(or `python scripts/rebuild.py --path {source_arg} --db {target_db}`)."
     )
     raise RuntimeError(hint) from exc

--- a/tests/test_background_indexing.py
+++ b/tests/test_background_indexing.py
@@ -114,7 +114,7 @@ def test_reindex_background_returns_job_immediately(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     source = tmp_path / "src"
     source.mkdir()
@@ -140,7 +140,7 @@ def test_reindex_many_background(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     sa = tmp_path / "sa"
     sb = tmp_path / "sb"
@@ -171,7 +171,7 @@ def test_reindex_blocking_still_works(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     source = tmp_path / "src"
     source.mkdir()
@@ -189,7 +189,7 @@ def test_index_status_includes_background_jobs(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     source = tmp_path / "src"
     source.mkdir()

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -344,11 +344,11 @@ def test_index_status_includes_watcher_info(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
     # Patch FileWatcher.start to avoid real FS watching.
     monkeypatch.setattr(FileWatcher, "start", lambda self: None)
-    monkeypatch.setenv("RIFLUX_FILE_WATCHER", "1")
-    monkeypatch.setenv("RIFLUX_FILE_WATCHER_PATHS", str(tmp_path))
+    monkeypatch.setenv("RIFFLUX_FILE_WATCHER", "1")
+    monkeypatch.setenv("RIFFLUX_FILE_WATCHER_PATHS", str(tmp_path))
 
     source = tmp_path / "docs"
     source.mkdir()
@@ -370,7 +370,7 @@ def test_index_status_shows_disabled_when_no_watcher(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
     # File watcher not enabled.
 
     source = tmp_path / "docs"

--- a/tests/test_mcp_protocol_stdio.py
+++ b/tests/test_mcp_protocol_stdio.py
@@ -22,8 +22,8 @@ from tests.helpers import (
 async def _run_protocol_roundtrip(*, workspace: Path, db_path: Path, source_path: Path) -> None:
     python_exe = workspace / ".venv" / "Scripts" / "python.exe"
     env = os.environ.copy()
-    env["RIFLUX_DB_PATH"] = str(db_path)
-    env["RIFLUX_EMBEDDING_BACKEND"] = "hash"
+    env["RIFFLUX_DB_PATH"] = str(db_path)
+    env["RIFFLUX_EMBEDDING_BACKEND"] = "hash"
     existing_pythonpath = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = (
         f"src{os.pathsep}{existing_pythonpath}" if existing_pythonpath else "src"
@@ -106,7 +106,7 @@ def test_mcp_stdio_protocol_roundtrip(
     workspace = Path(__file__).resolve().parents[1]
     db_path = make_db_path("protocol-test.db")
     source_path = fixture_corpus_path
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     reindex_result = reindex(db_path=db_path, source_path=source_path, force=True)
     assert reindex_result["indexed_files"] >= 1

--- a/tests/test_mcp_protocol_streamable_http.py
+++ b/tests/test_mcp_protocol_streamable_http.py
@@ -110,8 +110,8 @@ def test_mcp_streamable_http_protocol_roundtrip(
 
     port = free_tcp_port()
     env = os.environ.copy()
-    env["RIFLUX_DB_PATH"] = str(db_path)
-    env["RIFLUX_EMBEDDING_BACKEND"] = "hash"
+    env["RIFFLUX_DB_PATH"] = str(db_path)
+    env["RIFFLUX_EMBEDDING_BACKEND"] = "hash"
     existing_pythonpath = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = (
         f"src{os.pathsep}{existing_pythonpath}" if existing_pythonpath else "src"

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -14,7 +14,7 @@ async def _call_tool(service, name: str, arguments: dict) -> dict:
 
 
 def test_create_server_registers_tools_with_schema_metadata(monkeypatch) -> None:
-    monkeypatch.setenv("RIFLUX_DB_PATH", "env-rifflux.db")
+    monkeypatch.setenv("RIFFLUX_DB_PATH", "env-rifflux.db")
 
     service = mcp_server.create_server()
 

--- a/tests/test_mcp_tools_contract.py
+++ b/tests/test_mcp_tools_contract.py
@@ -20,7 +20,7 @@ def test_mcp_tool_contracts_end_to_end(
     make_db_path: Callable[[str], Path],
     monkeypatch,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     source_path = fixture_corpus_path
     db_path = make_db_path("rifflux-tools.db")
@@ -70,7 +70,7 @@ def test_reindex_many_supports_multiple_input_locations(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     db_path = make_db_path("rifflux-tools-many.db")
     source_a = tmp_path / "source-a"
@@ -96,7 +96,7 @@ def test_reindex_many_prunes_stale_files(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     db_path = make_db_path("rifflux-tools-prune.db")
     source = tmp_path / "source"
@@ -123,7 +123,7 @@ def test_reindex_many_can_disable_stale_pruning(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
 
     db_path = make_db_path("rifflux-tools-no-prune.db")
     source = tmp_path / "source"
@@ -155,9 +155,9 @@ def test_reindex_many_respects_configured_exclude_globs(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
-    monkeypatch.setenv("RIFLUX_INDEX_INCLUDE_GLOBS", "*.md")
-    monkeypatch.setenv("RIFLUX_INDEX_EXCLUDE_GLOBS", ".venv/*")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_INDEX_INCLUDE_GLOBS", "*.md")
+    monkeypatch.setenv("RIFFLUX_INDEX_EXCLUDE_GLOBS", ".venv/*")
 
     db_path = make_db_path("rifflux-tools-exclude.db")
     source = tmp_path / "source"
@@ -190,7 +190,7 @@ def test_operational_error_includes_rebuild_hint(
         index_status(db_path=db_path)
 
     message = str(exc_info.value)
-    assert "riflux-rebuild" in message
+    assert "rifflux-rebuild" in message
     assert str(db_path) in message
 
 
@@ -199,9 +199,9 @@ def test_search_can_auto_reindex_when_enabled(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
-    monkeypatch.setenv("RIFLUX_AUTO_REINDEX_ON_SEARCH", "1")
-    monkeypatch.setenv("RIFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS", "0")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_AUTO_REINDEX_ON_SEARCH", "1")
+    monkeypatch.setenv("RIFFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS", "0")
 
     source = tmp_path / "source"
     source.mkdir(parents=True, exist_ok=True)
@@ -213,7 +213,7 @@ def test_search_can_auto_reindex_when_enabled(
         "cache ttl policy repeated for chunk sizing coverage.",
         encoding="utf-8",
     )
-    monkeypatch.setenv("RIFLUX_AUTO_REINDEX_PATHS", str(source))
+    monkeypatch.setenv("RIFFLUX_AUTO_REINDEX_PATHS", str(source))
 
     db_path = make_db_path("rifflux-tools-auto-reindex.db")
 

--- a/tests/test_parallel_tools.py
+++ b/tests/test_parallel_tools.py
@@ -21,7 +21,7 @@ def indexed_db(
     make_db_path: Callable[[str], Path],
     monkeypatch,
 ) -> Path:
-    monkeypatch.setenv("RIFLUX_EMBEDDING_BACKEND", "hash")
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
     db_path = make_db_path("parallel.db")
     reindex(db_path=db_path, source_path=fixture_corpus_path, force=True)
     return db_path


### PR DESCRIPTION
## Summary
- remove legacy RIFLUX_* handling and standardize runtime config on RIFFLUX_* only
- update CLI/MCP server/inspect script env reads to RIFFLUX_*
- fix typo in rebuild hint (ifflux-rebuild)
- migrate tests and README examples/reference to RIFFLUX_*
- update workspace MCP config at .vscode/mcp.json to RIFFLUX_*

## Validation
- python -m pytest tests/test_mcp_server_unit.py tests/test_mcp_protocol_stdio.py tests/test_mcp_protocol_streamable_http.py tests/test_mcp_tools_contract.py tests/test_background_indexing.py tests/test_file_watcher.py tests/test_parallel_tools.py
- result: 38 passed
