### PR TITLE
Use absolute paths in index and enable file watcher by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Rifflux embedding behavior is controlled by `RIFFLUX_*` environment variables.
 - `RIFFLUX_AUTO_REINDEX_ON_SEARCH=0|1` (default `0`)
 - `RIFFLUX_AUTO_REINDEX_PATHS=.` (comma-separated paths)
 - `RIFFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS=2.0`
-- `RIFFLUX_FILE_WATCHER=0|1` (default `0`)
+- `RIFFLUX_FILE_WATCHER=0|1` (default `1`)
 - `RIFFLUX_FILE_WATCHER_PATHS=` (comma-separated directories to watch; required when watcher is enabled)
 - `RIFFLUX_FILE_WATCHER_DEBOUNCE_MS=500` (minimum ms between FS event batches)
 
@@ -82,7 +82,7 @@ Rifflux embedding behavior is controlled by `RIFFLUX_*` environment variables.
 | `RIFFLUX_AUTO_REINDEX_ON_SEARCH` | Whether search calls trigger incremental background refresh | `0` | `1` |
 | `RIFFLUX_AUTO_REINDEX_PATHS` | Paths scanned when auto-reindex on search is enabled | `.` | `docs,notes` |
 | `RIFFLUX_AUTO_REINDEX_MIN_INTERVAL_SECONDS` | Minimum seconds between auto-reindex runs per DB | `2.0` | `10.0` |
-| `RIFFLUX_FILE_WATCHER` | Whether filesystem watcher integration is enabled | `0` | `1` |
+| `RIFFLUX_FILE_WATCHER` | Whether filesystem watcher integration is enabled | `1` | `0` |
 | `RIFFLUX_FILE_WATCHER_PATHS` | Comma-separated directories monitored by watcher | empty | `docs,knowledge-base` |
 | `RIFFLUX_FILE_WATCHER_DEBOUNCE_MS` | Event debounce window before watcher emits a batch | `500` | `750` |
 | `RIFFLUX_LOG_LEVEL` | Logging verbosity for CLI and MCP server | `WARNING` | `DEBUG` |

--- a/src/rifflux/config.py
+++ b/src/rifflux/config.py
@@ -2,7 +2,6 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-
 DEFAULT_DB_PATH = Path(".tmp") / "rifflux" / "rifflux.db"
 
 

--- a/src/rifflux/config.py
+++ b/src/rifflux/config.py
@@ -30,6 +30,8 @@ class RiffluxConfig:
     index_include_globs: tuple[str, ...] = ("*.md",)
     index_exclude_globs: tuple[str, ...] = (
         ".git/*",
+        ".tmp/*",
+        "**/.tmp/*",
         ".venv/*",
         "**/__pycache__/*",
         "**/.pytest_cache/*",
@@ -39,7 +41,7 @@ class RiffluxConfig:
     auto_reindex_on_search: bool = False
     auto_reindex_paths: tuple[str, ...] = (".",)
     auto_reindex_min_interval_seconds: float = 2.0
-    file_watcher_enabled: bool = False
+    file_watcher_enabled: bool = True
     file_watcher_paths: tuple[str, ...] = ()
     file_watcher_debounce_ms: int = 500
 
@@ -56,7 +58,7 @@ class RiffluxConfig:
         index_exclude_globs = _parse_glob_list(
             _env(
                 "INDEX_EXCLUDE_GLOBS",
-                ".git/*,.venv/*,**/__pycache__/*,**/.pytest_cache/*,**/.ruff_cache/*,**/node_modules/*",
+                ".git/*,.tmp/*,**/.tmp/*,.venv/*,**/__pycache__/*,**/.pytest_cache/*,**/.ruff_cache/*,**/node_modules/*",
             )
         )
         auto_reindex_on_search = _parse_bool(
@@ -69,7 +71,7 @@ class RiffluxConfig:
             _env("AUTO_REINDEX_MIN_INTERVAL_SECONDS", "2.0")
         )
         file_watcher_enabled = _parse_bool(
-            _env("FILE_WATCHER", "0")
+            _env("FILE_WATCHER", "1")
         )
         file_watcher_paths = _parse_glob_list(
             _env("FILE_WATCHER_PATHS", "")

--- a/src/rifflux/indexing/indexer.py
+++ b/src/rifflux/indexing/indexer.py
@@ -58,11 +58,12 @@ class Indexer:
 
         for file_path in file_candidates:
             rel = normalize_path(str(file_path.relative_to(source_root)))
+            abs_path = normalize_path(str(file_path.resolve()))
             if not self._is_included(rel) or self._is_excluded(rel):
                 continue
-            seen_paths.append(rel)
+            seen_paths.append(abs_path)
             stat = file_path.stat()
-            existing = file_meta_map.get(rel)
+            existing = file_meta_map.get(abs_path)
 
             # Fast path: mtime + size unchanged → skip without reading file
             if (
@@ -71,7 +72,7 @@ class Indexer:
                 and int(existing["mtime_ns"]) == int(stat.st_mtime_ns)
                 and int(existing["size_bytes"]) == int(stat.st_size)
             ):
-                logger.debug("skip (stat match) %s", rel)
+                logger.debug("skip (stat match) %s", abs_path)
                 skipped += 1
                 continue
 
@@ -86,9 +87,9 @@ class Indexer:
                 and existing
                 and str(existing["sha256"]) == sha256
             ):
-                logger.debug("skip (hash match, stat updated) %s", rel)
+                logger.debug("skip (hash match, stat updated) %s", abs_path)
                 self.store.upsert_file(
-                    path=rel,
+                    path=abs_path,
                     mtime_ns=int(stat.st_mtime_ns),
                     size_bytes=int(stat.st_size),
                     sha256=sha256,
@@ -98,7 +99,7 @@ class Indexer:
 
             t_file = time.perf_counter()
             file_id = self.store.upsert_file(
-                path=rel,
+                path=abs_path,
                 mtime_ns=int(stat.st_mtime_ns),
                 size_bytes=int(stat.st_size),
                 sha256=sha256,
@@ -107,7 +108,7 @@ class Indexer:
             text = content_bytes.decode("utf-8")
             chunks = chunk_markdown(
                 text,
-                rel,
+                abs_path,
                 max_chunk_chars=self.max_chunk_chars,
                 min_chunk_chars=self.min_chunk_chars,
             )
@@ -127,7 +128,7 @@ class Indexer:
                 )
 
             dt_file = time.perf_counter() - t_file
-            logger.debug("indexed %s chunks=%d in %.3fs", rel, len(chunks), dt_file)
+            logger.debug("indexed %s chunks=%d in %.3fs", abs_path, len(chunks), dt_file)
             indexed += 1
         self.store.commit()
         dt = time.perf_counter() - t_start

--- a/src/rifflux/indexing/indexer.py
+++ b/src/rifflux/indexing/indexer.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import hashlib
 import logging
 import time
-from fnmatch import fnmatch
 from collections.abc import Callable
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -50,8 +50,14 @@ class Indexer:
         seen_paths: list[str] = []
         root = root.resolve()
         source_root = root.parent if root.is_file() else root
-        file_candidates = [root] if root.is_file() else [path for path in root.rglob("*") if path.is_file()]
-        logger.debug("reindex_path root=%s candidates=%d force=%s", root, len(file_candidates), force)
+        file_candidates = (
+            [root] if root.is_file()
+            else [path for path in root.rglob("*") if path.is_file()]
+        )
+        logger.debug(
+            "reindex_path root=%s candidates=%d force=%s",
+            root, len(file_candidates), force,
+        )
 
         # Bulk-load existing file metadata to avoid per-file DB queries.
         file_meta_map = self.store.get_all_file_meta()

--- a/src/rifflux/mcp/server.py
+++ b/src/rifflux/mcp/server.py
@@ -14,10 +14,20 @@ from pydantic import Field
 from rifflux.config import RiffluxConfig
 from rifflux.mcp.tools import (
     get_chunk as mcp_get_chunk,
+)
+from rifflux.mcp.tools import (
     get_file as mcp_get_file,
+)
+from rifflux.mcp.tools import (
     index_status as mcp_index_status,
+)
+from rifflux.mcp.tools import (
     reindex as mcp_reindex,
+)
+from rifflux.mcp.tools import (
     reindex_many as mcp_reindex_many,
+)
+from rifflux.mcp.tools import (
     search_rifflux as mcp_search_rifflux,
 )
 

--- a/src/rifflux/mcp/server.py
+++ b/src/rifflux/mcp/server.py
@@ -67,10 +67,10 @@ def create_server(db_path: Path | None = None) -> FastMCP:
     async def get_file(
         path: Annotated[
             str,
-            Field(description="Source file path to retrieve from the index."),
+            Field(description="Absolute source file path to retrieve from the index."),
         ]
     ) -> dict[str, Any]:
-        """Get all indexed chunks and metadata for a specific source file path."""
+        """Get all indexed chunks and metadata for a specific absolute source file path."""
         return await anyio.to_thread.run_sync(
             partial(mcp_get_file, resolved_db_path, path=path),
         )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,7 +20,7 @@ EXPECTED_MCP_TOOL_DESCRIPTIONS = {
         "Get one indexed chunk by stable chunk ID, including metadata and content."
     ),
     "get_file": (
-        "Get all indexed chunks and metadata for a specific source file path."
+        "Get all indexed chunks and metadata for a specific absolute source file path."
     ),
     "index_status": (
         "Report current index counts and embedding backend/model configuration."
@@ -38,7 +38,7 @@ EXPECTED_MCP_TOOL_PARAM_DESCRIPTIONS = {
         "chunk_id": "Stable chunk identifier returned by search results.",
     },
     "get_file": {
-        "path": "Source file path to retrieve from the index.",
+        "path": "Absolute source file path to retrieve from the index.",
     },
     "index_status": {},
     "reindex": {

--- a/tests/test_mcp_tools_contract.py
+++ b/tests/test_mcp_tools_contract.py
@@ -1,6 +1,6 @@
+import sqlite3
 from collections.abc import Callable
 from pathlib import Path
-import sqlite3
 
 import pytest
 

--- a/tests/test_mcp_tools_contract.py
+++ b/tests/test_mcp_tools_contract.py
@@ -54,6 +54,7 @@ def test_mcp_tool_contracts_end_to_end(
         "content",
         "score_breakdown",
     }.issubset(first)
+    assert Path(first["path"]).is_absolute()
 
     chunk = get_chunk(db_path=db_path, chunk_id=first["chunk_id"])
     assert "chunk" in chunk
@@ -89,6 +90,49 @@ def test_reindex_many_supports_multiple_input_locations(
     assert len(result["indexed_paths"]) == 2
     assert "embedding_model" in result
     assert "git_fingerprint" in result
+
+
+def test_search_returns_absolute_paths_for_multi_root_indexes(
+    make_db_path: Callable[[str], Path],
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+
+    db_path = make_db_path("rifflux-tools-absolute-paths.db")
+    source_a = tmp_path / "source-a"
+    source_b = tmp_path / "source-b"
+    source_a.mkdir(parents=True, exist_ok=True)
+    source_b.mkdir(parents=True, exist_ok=True)
+
+    file_a = source_a / "shared.md"
+    file_b = source_b / "shared.md"
+    file_a.write_text(
+        "# A\n\n"
+        "cache ttl policy in source a repeated for chunk sizing coverage. "
+        "cache ttl policy in source a repeated for chunk sizing coverage. "
+        "cache ttl policy in source a repeated for chunk sizing coverage.",
+        encoding="utf-8",
+    )
+    file_b.write_text(
+        "# B\n\n"
+        "cache ttl policy in source b repeated for chunk sizing coverage. "
+        "cache ttl policy in source b repeated for chunk sizing coverage. "
+        "cache ttl policy in source b repeated for chunk sizing coverage.",
+        encoding="utf-8",
+    )
+
+    reindex_many(db_path=db_path, source_paths=[source_a, source_b], force=True)
+
+    search = search_rifflux(db_path=db_path, query="cache ttl policy", top_k=10, mode="lexical")
+    assert search["count"] == 2
+
+    returned_paths = {row["path"] for row in search["results"]}
+    expected_paths = {
+        str(file_a.resolve()).replace("\\", "/"),
+        str(file_b.resolve()).replace("\\", "/"),
+    }
+    assert returned_paths == expected_paths
 
 
 def test_reindex_many_prunes_stale_files(
@@ -173,6 +217,28 @@ def test_reindex_many_respects_configured_exclude_globs(
     assert status["files"] == 1
     assert status["index_include_globs"] == ["*.md"]
     assert status["index_exclude_globs"] == [".venv/*"]
+
+
+def test_reindex_many_excludes_tmp_by_default(
+    make_db_path: Callable[[str], Path],
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+
+    db_path = make_db_path("rifflux-tools-default-tmp-exclude.db")
+    source = tmp_path / "source"
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "keep.md").write_text("# Keep\n\ncache ttl", encoding="utf-8")
+    (source / ".tmp").mkdir(parents=True, exist_ok=True)
+    (source / ".tmp" / "skip.md").write_text("# Skip\n\nbenchmark corpus", encoding="utf-8")
+
+    result = reindex_many(db_path=db_path, source_paths=[source], force=True)
+    assert result["indexed_files"] == 1
+
+    status = index_status(db_path=db_path)
+    assert status["files"] == 1
+    assert ".tmp/*" in status["index_exclude_globs"]
 
 
 def test_operational_error_includes_rebuild_hint(


### PR DESCRIPTION
## Summary

Switches the indexer to store absolute file paths (instead of relative) so multi-root indexes never collide on identically named files across different source trees. Also enables the file watcher by default and excludes `.tmp/` directories from indexing.

## Background

When multiple source roots are indexed into the same database, relative paths like `shared.md` from different directories overwrote each other. Storing absolute paths makes each entry unique. Separately, the file watcher was opt-in (`RIFFLUX_FILE_WATCHER=0`) but should be on by default for a better out-of-the-box experience. The `.tmp/` directory (used for benchmark artifacts and DB files) was not excluded, causing self-indexing loops.

## Changes

- **`src/rifflux/indexing/indexer.py`** — resolve and store absolute paths for file metadata, chunk IDs, and log messages; fix import sort and line length lint
- **`src/rifflux/mcp/server.py`** — update `get_file` tool description to reference absolute paths; fix import sort lint
- **`tests/helpers.py`** — update expected tool descriptions to match absolute-path wording
- **`tests/test_mcp_tools_contract.py`** — add `test_search_returns_absolute_paths_for_multi_root_indexes` and `test_reindex_many_excludes_tmp_by_default`; fix import sort lint
- **`src/rifflux/config.py`** — set `file_watcher_enabled` default to `True`, env default to `1`; add `.tmp/*` and `**/.tmp/*` to default exclude globs; fix import sort lint
- **`README.md`** — update env var reference table and summary to reflect new defaults

## Testing

- All 87 tests pass (`pytest --tb=short -q`)
- Zero lint issues on changed files (`ruff check`)
- New tests cover multi-root absolute-path correctness and `.tmp` exclusion behavior

## Additional Notes

- To disable the watcher, set `RIFFLUX_FILE_WATCHER=0`
- Existing databases should be rebuilt (`rifflux-rebuild`) to migrate stored paths from relative to absolute
