### PR TITLE
feat: add 2nd-degree chunk expansion to search_rifflux

### DIFF
--- a/src/rifflux/db/sqlite_store.py
+++ b/src/rifflux/db/sqlite_store.py
@@ -228,6 +228,39 @@ class SqliteStore:
             return None
         return {"path": path, "chunks": rows}
 
+    def get_sibling_chunks(
+        self,
+        file_path: str,
+        chunk_index: int,
+        window: int = 2,
+    ) -> list[dict[str, Any]]:
+        """Return chunks from the same file within ±window of chunk_index."""
+        cur = self.conn.execute(
+            """
+            SELECT c.chunk_id, f.path, c.heading_path, c.chunk_index, c.content
+            FROM chunks c
+            JOIN files f ON f.id = c.file_id
+            WHERE f.path = ?
+              AND c.chunk_index BETWEEN ? AND ?
+              AND c.chunk_index != ?
+            ORDER BY c.chunk_index ASC
+            """,
+            (file_path, chunk_index - window, chunk_index + window, chunk_index),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+    def get_embedding(self, chunk_id: str) -> np.ndarray | None:
+        """Return the stored embedding vector for a chunk, or None."""
+        cur = self.conn.execute(
+            "SELECT dim, vec FROM embeddings WHERE chunk_id = ?",
+            (chunk_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        dim = int(row["dim"])
+        return np.frombuffer(row["vec"], dtype=np.float32, count=dim).copy()
+
 
 def _normalize_fts_query(query: str) -> str | None:
     terms = [token for token in re.findall(r"\w+", query, flags=re.UNICODE) if token]

--- a/src/rifflux/mcp/server.py
+++ b/src/rifflux/mcp/server.py
@@ -55,10 +55,27 @@ def create_server(db_path: Path | None = None) -> FastMCP:
             Literal["lexical", "semantic", "hybrid"],
             Field(description="Retrieval mode: lexical, semantic, or hybrid."),
         ] = "hybrid",
+        expand: Annotated[
+            bool,
+            Field(
+                description=(
+                    "When true, return a 'related' list of 2nd-degree chunks: "
+                    "sibling chunks from the same file and semantically similar "
+                    "chunks from other files."
+                ),
+            ),
+        ] = False,
     ) -> dict[str, Any]:
         """Search indexed content using lexical, semantic, or hybrid retrieval modes."""
         return await anyio.to_thread.run_sync(
-            partial(mcp_search_rifflux, resolved_db_path, query=query, top_k=top_k, mode=mode),
+            partial(
+                mcp_search_rifflux,
+                resolved_db_path,
+                query=query,
+                top_k=top_k,
+                mode=mode,
+                expand=expand,
+            ),
         )
 
     @mcp.tool()

--- a/src/rifflux/mcp/tools.py
+++ b/src/rifflux/mcp/tools.py
@@ -356,7 +356,7 @@ def search_rifflux(
                 "auto_reindex": auto_reindex,
                 "results": results,
             }
-            if expand and results:
+            if expand:
                 related = search.expand(results)
                 response["related"] = related
                 response["related_count"] = len(related)

--- a/src/rifflux/mcp/tools.py
+++ b/src/rifflux/mcp/tools.py
@@ -331,9 +331,13 @@ def search_rifflux(
     query: str,
     top_k: int = 10,
     mode: str = "hybrid",
+    expand: bool = False,
 ) -> dict[str, Any]:
     t_start = time.perf_counter()
-    logger.debug("search_rifflux start query=%r top_k=%d mode=%s", query, top_k, mode)
+    logger.debug(
+        "search_rifflux start query=%r top_k=%d mode=%s expand=%s",
+        query, top_k, mode, expand,
+    )
     runtime_config = RiffluxConfig.from_env()
     try:
         # Initialise schema/connection first so the DB is ready before any
@@ -344,9 +348,7 @@ def search_rifflux(
         _maybe_start_file_watcher(db_path, runtime_config)
         try:
             results = search.search(query, top_k=top_k, mode=mode)
-            dt = time.perf_counter() - t_start
-            logger.debug("search_rifflux done in %.3fs count=%d", dt, len(results))
-            return {
+            response: dict[str, Any] = {
                 "query": query,
                 "mode": mode,
                 "count": len(results),
@@ -354,6 +356,13 @@ def search_rifflux(
                 "auto_reindex": auto_reindex,
                 "results": results,
             }
+            if expand and results:
+                related = search.expand(results)
+                response["related"] = related
+                response["related_count"] = len(related)
+            dt = time.perf_counter() - t_start
+            logger.debug("search_rifflux done in %.3fs count=%d", dt, len(results))
+            return response
         finally:
             store.close()
     except sqlite3.OperationalError as exc:

--- a/src/rifflux/retrieval/search.py
+++ b/src/rifflux/retrieval/search.py
@@ -14,6 +14,11 @@ from rifflux.retrieval.semantic import semantic_search
 
 logger = logging.getLogger("rifflux.retrieval")
 
+# Defaults for expansion parameters.
+_DEFAULT_EXPAND_SEEDS = 3
+_DEFAULT_SIBLING_WINDOW = 2
+_DEFAULT_SEMANTIC_EXPAND_K = 5
+
 
 class SearchService:
     def __init__(
@@ -104,3 +109,71 @@ class SearchService:
 
     def get_file(self, path: str) -> dict[str, Any] | None:
         return self.store.get_file(path)
+
+    def expand(
+        self,
+        results: list[dict[str, Any]],
+        *,
+        max_seeds: int = _DEFAULT_EXPAND_SEEDS,
+        sibling_window: int = _DEFAULT_SIBLING_WINDOW,
+        semantic_k: int = _DEFAULT_SEMANTIC_EXPAND_K,
+    ) -> list[dict[str, Any]]:
+        """Return 2nd-degree related chunks for the given search results.
+
+        Expansion produces two pools:
+        1. Sibling chunks from the same file (±sibling_window), in doc order.
+        2. Cross-file semantically similar chunks via stored embeddings.
+        Both pools are deduped against the seed chunk_ids.
+        """
+        t0 = time.perf_counter()
+        seed_ids: set[str] = {r["chunk_id"] for r in results}
+        seen_ids: set[str] = set(seed_ids)
+        siblings: list[dict[str, Any]] = []
+        cross_file: list[dict[str, Any]] = []
+
+        seeds = results[:max_seeds]
+
+        # 1. Sibling expansion
+        for seed in seeds:
+            for sib in self.store.get_sibling_chunks(
+                seed["path"], seed["chunk_index"], window=sibling_window,
+            ):
+                if sib["chunk_id"] not in seen_ids:
+                    seen_ids.add(sib["chunk_id"])
+                    sib["relation"] = "sibling"
+                    siblings.append(sib)
+
+        # 2. Cross-file semantic expansion
+        if self.embed_query is not None:
+            for seed in seeds:
+                seed_vec = self.store.get_embedding(seed["chunk_id"])
+                if seed_vec is None:
+                    continue
+                neighbors = semantic_search(
+                    self.store, seed_vec, top_k=semantic_k + len(seen_ids),
+                )
+                for neighbor in neighbors:
+                    if neighbor["chunk_id"] in seen_ids:
+                        continue
+                    seen_ids.add(neighbor["chunk_id"])
+                    cross_file.append({
+                        "chunk_id": neighbor["chunk_id"],
+                        "path": neighbor["path"],
+                        "heading_path": neighbor["heading_path"],
+                        "chunk_index": neighbor["chunk_index"],
+                        "content": neighbor["content"],
+                        "relation": "semantic",
+                        "cosine": neighbor["cosine"],
+                    })
+                    if len(cross_file) >= semantic_k:
+                        break
+                if len(cross_file) >= semantic_k:
+                    break
+
+        related = siblings + cross_file
+        dt = time.perf_counter() - t0
+        logger.debug(
+            "expand done in %.3fs siblings=%d cross_file=%d",
+            dt, len(siblings), len(cross_file),
+        )
+        return related

--- a/src/rifflux/retrieval/search.py
+++ b/src/rifflux/retrieval/search.py
@@ -155,6 +155,8 @@ class SearchService:
                 for neighbor in neighbors:
                     if neighbor["chunk_id"] in seen_ids:
                         continue
+                    if neighbor["path"] == seed["path"]:
+                        continue
                     seen_ids.add(neighbor["chunk_id"])
                     cross_file.append({
                         "chunk_id": neighbor["chunk_id"],

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,6 +33,11 @@ EXPECTED_MCP_TOOL_PARAM_DESCRIPTIONS = {
         "query": "Natural-language query to search indexed content.",
         "top_k": "Maximum number of results to return (1-100).",
         "mode": "Retrieval mode: lexical, semantic, or hybrid.",
+        "expand": (
+            "When true, return a 'related' list of 2nd-degree chunks: "
+            "sibling chunks from the same file and semantically similar "
+            "chunks from other files."
+        ),
     },
     "get_chunk": {
         "chunk_id": "Stable chunk identifier returned by search results.",

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -44,6 +44,7 @@ def test_create_server_tool_wrappers_delegate_to_mcp_tools(monkeypatch, tmp_path
         query: str,
         top_k: int = 10,
         mode: str = "hybrid",
+        expand: bool = False,
     ) -> dict:
         calls["search"] = (db_path, query, top_k, mode)
         return {"tool": "search"}

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -46,7 +46,7 @@ def test_create_server_tool_wrappers_delegate_to_mcp_tools(monkeypatch, tmp_path
         mode: str = "hybrid",
         expand: bool = False,
     ) -> dict:
-        calls["search"] = (db_path, query, top_k, mode)
+        calls["search"] = (db_path, query, top_k, mode, expand)
         return {"tool": "search"}
 
     def fake_get_chunk(db_path: Path | None, chunk_id: str) -> dict:
@@ -96,7 +96,7 @@ def test_create_server_tool_wrappers_delegate_to_mcp_tools(monkeypatch, tmp_path
             _call_tool,
             service,
             "search_rifflux",
-            {"query": "cache", "top_k": 3, "mode": "lexical"},
+            {"query": "cache", "top_k": 3, "mode": "lexical", "expand": True},
         )
     )
     chunk_result = anyio.run(partial(_call_tool, service, "get_chunk", {"chunk_id": "cid-1"}))
@@ -126,7 +126,7 @@ def test_create_server_tool_wrappers_delegate_to_mcp_tools(monkeypatch, tmp_path
     assert many_result == {"tool": "reindex_many"}
     assert single_result == {"tool": "reindex"}
 
-    assert calls["search"] == (db_path, "cache", 3, "lexical")
+    assert calls["search"] == (db_path, "cache", 3, "lexical", True)
     assert calls["chunk"] == (db_path, "cid-1")
     assert calls["file"] == (db_path, "notes.md")
     assert calls["status"] == db_path

--- a/tests/test_mcp_tools_contract.py
+++ b/tests/test_mcp_tools_contract.py
@@ -387,6 +387,7 @@ def test_search_expand_returns_sibling_chunks(
     # Sibling chunks should come from the same file as the seed
     seed_path = result["results"][0]["path"]
     sibling_related = [r for r in result["related"] if r["relation"] == "sibling"]
+    assert len(sibling_related) >= 1
     for sib in sibling_related:
         assert sib["path"] == seed_path
 
@@ -467,6 +468,36 @@ def test_search_expand_includes_cross_file_semantic(
 
     assert result["count"] >= 1
     related = result.get("related", [])
-    # With hash embeddings and cross-file content, we should get some related.
-    # At minimum siblings should be present
     assert len(related) >= 1
+
+    seed_path = result["results"][0]["path"]
+    semantic_related = [r for r in related if r["relation"] == "semantic"]
+    assert len(semantic_related) >= 1
+    for semantic in semantic_related:
+        assert semantic["path"] != seed_path
+
+
+def test_search_expand_true_includes_empty_related_when_no_results(
+    make_db_path: Callable[[str], Path],
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+
+    db_path = make_db_path("rifflux-expand-empty.db")
+    corpus = tmp_path / "corpus"
+    _write_multi_chunk_corpus(corpus)
+
+    reindex_many(db_path=db_path, source_paths=[corpus], force=True)
+
+    result = search_rifflux(
+        db_path=db_path,
+        query="query-without-any-hits-xyzzy",
+        top_k=3,
+        mode="lexical",
+        expand=True,
+    )
+
+    assert result["count"] == 0
+    assert result["related"] == []
+    assert result["related_count"] == 0

--- a/tests/test_mcp_tools_contract.py
+++ b/tests/test_mcp_tools_contract.py
@@ -321,3 +321,152 @@ def test_search_can_auto_reindex_when_enabled(
         mode="hybrid",
     )
     assert second2["count"] >= 1
+
+
+def _write_multi_chunk_corpus(root: Path) -> None:
+    """Write a corpus with multiple chunks in one file and a second related file."""
+    root.mkdir(parents=True, exist_ok=True)
+    # File with multiple heading sections → multiple chunks
+    (root / "guide.md").write_text(
+        "# Guide\n\n"
+        "## Introduction\n\n"
+        "This introduction covers cache ttl policies and expiry strategies "
+        "for local development workflows. Cache ttl policies are critical "
+        "for reliable offline retrieval.\n\n"
+        "## Configuration\n\n"
+        "Configuration of cache ttl parameters including max-age, stale-while-"
+        "revalidate, and expiry windows for different content types.\n\n"
+        "## Advanced\n\n"
+        "Advanced cache ttl tuning with sliding windows, adaptive refresh "
+        "intervals, and capacity-based eviction policies for large corpora.\n",
+        encoding="utf-8",
+    )
+    # Second file with related content
+    (root / "reference.md").write_text(
+        "# Reference\n\n"
+        "## Cache Invalidation\n\n"
+        "Cache invalidation patterns and cache ttl best practices for "
+        "distributed systems and local indexes. Covers write-through, "
+        "write-behind, and refresh-ahead strategies.\n",
+        encoding="utf-8",
+    )
+
+
+def test_search_expand_returns_sibling_chunks(
+    make_db_path: Callable[[str], Path],
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+
+    db_path = make_db_path("rifflux-expand-siblings.db")
+    corpus = tmp_path / "corpus"
+    _write_multi_chunk_corpus(corpus)
+
+    reindex_many(db_path=db_path, source_paths=[corpus], force=True)
+
+    result = search_rifflux(
+        db_path=db_path,
+        query="cache ttl",
+        top_k=1,
+        mode="lexical",
+        expand=True,
+    )
+
+    assert "related" in result
+    assert "related_count" in result
+    assert result["related_count"] >= 1
+
+    # Related chunks should have a "relation" field
+    for related in result["related"]:
+        assert related["relation"] in {"sibling", "semantic"}
+        assert "chunk_id" in related
+        assert "path" in related
+        assert "content" in related
+
+    # Sibling chunks should come from the same file as the seed
+    seed_path = result["results"][0]["path"]
+    sibling_related = [r for r in result["related"] if r["relation"] == "sibling"]
+    for sib in sibling_related:
+        assert sib["path"] == seed_path
+
+
+def test_search_expand_deduplicates_against_results(
+    make_db_path: Callable[[str], Path],
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+
+    db_path = make_db_path("rifflux-expand-dedup.db")
+    corpus = tmp_path / "corpus"
+    _write_multi_chunk_corpus(corpus)
+
+    reindex_many(db_path=db_path, source_paths=[corpus], force=True)
+
+    result = search_rifflux(
+        db_path=db_path,
+        query="cache ttl",
+        top_k=5,
+        mode="hybrid",
+        expand=True,
+    )
+
+    result_ids = {r["chunk_id"] for r in result["results"]}
+    related_ids = {r["chunk_id"] for r in result.get("related", [])}
+    # No overlap between results and related
+    assert result_ids.isdisjoint(related_ids)
+
+
+def test_search_expand_false_omits_related(
+    make_db_path: Callable[[str], Path],
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+
+    db_path = make_db_path("rifflux-expand-off.db")
+    corpus = tmp_path / "corpus"
+    _write_multi_chunk_corpus(corpus)
+
+    reindex_many(db_path=db_path, source_paths=[corpus], force=True)
+
+    result = search_rifflux(
+        db_path=db_path,
+        query="cache ttl",
+        top_k=3,
+        mode="hybrid",
+        expand=False,
+    )
+
+    assert "related" not in result
+    assert "related_count" not in result
+
+
+def test_search_expand_includes_cross_file_semantic(
+    make_db_path: Callable[[str], Path],
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("RIFFLUX_EMBEDDING_BACKEND", "hash")
+
+    db_path = make_db_path("rifflux-expand-crossfile.db")
+    corpus = tmp_path / "corpus"
+    _write_multi_chunk_corpus(corpus)
+
+    reindex_many(db_path=db_path, source_paths=[corpus], force=True)
+
+    # Search narrowly so we get results from one file, then expand
+    result = search_rifflux(
+        db_path=db_path,
+        query="introduction cache ttl policies",
+        top_k=1,
+        mode="lexical",
+        expand=True,
+    )
+
+    assert result["count"] >= 1
+    related = result.get("related", [])
+    # With hash embeddings and cross-file content, we should get some related.
+    # At minimum siblings should be present
+    assert len(related) >= 1


### PR DESCRIPTION
## Summary

Add a 2nd-degree chunk expansion feature to `search_rifflux`. When `expand=true`, the response includes a `related` list containing sibling chunks from the same file and semantically similar chunks from other files, enabling agents to gather surrounding context without multiple round-trips.

## Background

Closes #8

Search results return individual chunks but agents often need surrounding context — adjacent sections in the same document or related content in other files. This feature surfaces that context in a single call.

## Changes

- **`src/rifflux/db/sqlite_store.py`**: Added `get_sibling_chunks(file_path, chunk_index, window)` and `get_embedding(chunk_id)` methods.
- **`src/rifflux/retrieval/search.py`**: Added `expand()` method to `SearchService` — collects sibling chunks (doc order) from top-N seeds and cross-file semantic neighbors via stored embeddings, deduplicates against seed results.
- **`src/rifflux/mcp/server.py`**: Added `expand` boolean parameter to the `search_rifflux` MCP tool schema.
- **`src/rifflux/mcp/tools.py`**: Wired `expand` through to `SearchService.expand()`, adding `related` and `related_count` to the response dict.
- **`tests/test_mcp_server_unit.py`**: Updated `fake_search` to accept `expand` kwarg.
- **`tests/helpers.py`**: Added `expand` to `EXPECTED_MCP_TOOL_PARAM_DESCRIPTIONS`.
- **`tests/test_mcp_tools_contract.py`**: Added 4 new tests: sibling expansion, deduplication, expand=false omission, cross-file semantic expansion.

## Testing

- All 91 tests pass (`pytest --tb=short -q`).
- Lint check (`ruff check`) shows no new errors (13 pre-existing, unchanged).
- New tests cover: sibling chunk retrieval, deduplication against primary results, expand=false returns no related key, cross-file semantic expansion with hash embeddings.
